### PR TITLE
Not add/add S3DistCp for shredded JSONs and shredded TSVs depending on the configuration

### DIFF
--- a/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -605,24 +605,26 @@ module Snowplow
             copy_atomic_events_to_s3_step_config = {:step => copy_atomic_events_to_s3_step, :retry_on_fail => true, :rdb_loader_log => nil}
             submit_jobflow_step(copy_atomic_events_to_s3_step_config, use_persistent_jobflow)
 
-            # Copy shredded JSONs (pre-R32)
-            copy_shredded_types_to_s3_step = Elasticity::S3DistCpStep.new(legacy = @legacy)
-            copy_shredded_types_to_s3_step.arguments = [
-              "--src"       , SHRED_STEP_OUTPUT,
-              "--dest"      , shred_final_output,
-              "--groupBy"   , SHREDDED_TYPES_PARTFILE_GROUPBY_REGEXP,
-              "--targetSize", "24",
-              "--s3Endpoint", s3_endpoint
-            ] + output_codec
-            if encrypted
-              copy_shredded_types_to_s3_step.arguments = copy_shredded_types_to_s3_step.arguments + [ '--s3ServerSideEncryption' ]
+            # Copy shredded JSONs (if shredder version < 0.16.0 or >= 0.16.0 and tabularBlacklist non empty)
+            if should_copy_shredded_JSONs(shredder_version, SHRED_JOB_WITH_TSV_OUTPUT, targets[:ENRICHED_EVENTS])
+              copy_shredded_types_to_s3_step = Elasticity::S3DistCpStep.new(legacy = @legacy)
+              copy_shredded_types_to_s3_step.arguments = [
+                "--src"       , SHRED_STEP_OUTPUT,
+                "--dest"      , shred_final_output,
+                "--groupBy"   , SHREDDED_TYPES_PARTFILE_GROUPBY_REGEXP,
+                "--targetSize", "24",
+                "--s3Endpoint", s3_endpoint
+              ] + output_codec
+              if encrypted
+                copy_shredded_types_to_s3_step.arguments = copy_shredded_types_to_s3_step.arguments + [ '--s3ServerSideEncryption' ]
+              end
+              copy_shredded_types_to_s3_step.name = "[shred] s3-dist-cp: Shredded JSON types HDFS -> S3"
+              copy_shredded_types_to_s3_step_config = {:step => copy_shredded_types_to_s3_step, :retry_on_fail => true, :rdb_loader_log => nil}
+              submit_jobflow_step(copy_shredded_types_to_s3_step_config, use_persistent_jobflow)
             end
-            copy_shredded_types_to_s3_step.name = "[shred] s3-dist-cp: Shredded JSON types HDFS -> S3"
-            copy_shredded_types_to_s3_step_config = {:step => copy_shredded_types_to_s3_step, :retry_on_fail => true, :rdb_loader_log => nil}
-            submit_jobflow_step(copy_shredded_types_to_s3_step_config, use_persistent_jobflow)
 
-            # Copy shredded TSVs (R32+)
-            if shredder_version >= SHRED_JOB_WITH_TSV_OUTPUT
+            # Copy shredded TSVs (if shredder version >= 0.16.0 and tabularBlacklist exists and is an array)
+            if should_copy_shredded_TSVs(shredder_version, SHRED_JOB_WITH_TSV_OUTPUT, targets[:ENRICHED_EVENTS])
               copy_shredded_tsv_types_to_s3_step = Elasticity::S3DistCpStep.new(legacy = @legacy)
               copy_shredded_tsv_types_to_s3_step.arguments = [
                 "--src"       , SHRED_STEP_OUTPUT,

--- a/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/absent
+++ b/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/absent
@@ -1,0 +1,22 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/4-0-0",
+  "data": {
+    "name": "com.snplow.eng.aws-dev1 Redshift",
+    "id": "354a3d25-7dc2-9c31-5605-19d6fd819efa",
+    "host": "sp-com-snplow-eng-aws-prod1-redshift-cluster.cdzqkzl74pqa.eu-central-1.redshift.amazonaws.com",
+    "database": "dev1",
+    "port": 5439,
+    "roleArn": "arn:aws:iam::866038399814:role/sp-com-snplow-eng-aws-prod1-redshift-load",
+    "schema": "atomic",
+    "username": "storageloader",
+    "password": "123",
+    "jdbc": {
+      "ssl": true
+    },
+    "processingManifest": null,
+    "maxError": 1,
+    "compRows": 200000,
+    "purpose": "ENRICHED_EVENTS",
+    "sshTunnel": null
+  }
+}

--- a/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/empty
+++ b/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/empty
@@ -1,0 +1,23 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/4-0-0",
+  "data": {
+    "name": "com.snplow.eng.aws-dev1 Redshift",
+    "id": "354a3d25-7dc2-9c31-5605-19d6fd819efa",
+    "host": "sp-com-snplow-eng-aws-prod1-redshift-cluster.cdzqkzl74pqa.eu-central-1.redshift.amazonaws.com",
+    "database": "dev1",
+    "port": 5439,
+    "roleArn": "arn:aws:iam::866038399814:role/sp-com-snplow-eng-aws-prod1-redshift-load",
+    "schema": "atomic",
+    "username": "storageloader",
+    "password": "123",
+    "jdbc": {
+      "ssl": true
+    },
+    "processingManifest": null,
+    "blacklistTabular": [],
+    "maxError": 1,
+    "compRows": 200000,
+    "purpose": "ENRICHED_EVENTS",
+    "sshTunnel": null
+  }
+}

--- a/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/non-empty
+++ b/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/non-empty
@@ -1,0 +1,23 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/4-0-0",
+  "data": {
+    "name": "com.snplow.eng.aws-dev1 Redshift",
+    "id": "354a3d25-7dc2-9c31-5605-19d6fd819efa",
+    "host": "sp-com-snplow-eng-aws-prod1-redshift-cluster.cdzqkzl74pqa.eu-central-1.redshift.amazonaws.com",
+    "database": "dev1",
+    "port": 5439,
+    "roleArn": "arn:aws:iam::866038399814:role/sp-com-snplow-eng-aws-prod1-redshift-load",
+    "schema": "atomic",
+    "username": "storageloader",
+    "password": "123",
+    "jdbc": {
+      "ssl": true
+    },
+    "processingManifest": null,
+    "blacklistTabular": ["iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-2"],
+    "maxError": 1,
+    "compRows": 200000,
+    "purpose": "ENRICHED_EVENTS",
+    "sshTunnel": null
+  }
+}

--- a/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/not-array
+++ b/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/not-array
@@ -1,0 +1,23 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/4-0-0",
+  "data": {
+    "name": "com.snplow.eng.aws-dev1 Redshift",
+    "id": "354a3d25-7dc2-9c31-5605-19d6fd819efa",
+    "host": "sp-com-snplow-eng-aws-prod1-redshift-cluster.cdzqkzl74pqa.eu-central-1.redshift.amazonaws.com",
+    "database": "dev1",
+    "port": 5439,
+    "roleArn": "arn:aws:iam::866038399814:role/sp-com-snplow-eng-aws-prod1-redshift-load",
+    "schema": "atomic",
+    "username": "storageloader",
+    "password": "123",
+    "jdbc": {
+      "ssl": true
+    },
+    "processingManifest": null,
+    "blacklistTabular": "iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-2",
+    "maxError": 1,
+    "compRows": 200000,
+    "purpose": "ENRICHED_EVENTS",
+    "sshTunnel": null
+  }
+}

--- a/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/null
+++ b/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/null
@@ -1,0 +1,23 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/4-0-0",
+  "data": {
+    "name": "com.snplow.eng.aws-dev1 Redshift",
+    "id": "354a3d25-7dc2-9c31-5605-19d6fd819efa",
+    "host": "sp-com-snplow-eng-aws-prod1-redshift-cluster.cdzqkzl74pqa.eu-central-1.redshift.amazonaws.com",
+    "database": "dev1",
+    "port": 5439,
+    "roleArn": "arn:aws:iam::866038399814:role/sp-com-snplow-eng-aws-prod1-redshift-load",
+    "schema": "atomic",
+    "username": "storageloader",
+    "password": "123",
+    "jdbc": {
+      "ssl": true
+    },
+    "processingManifest": null,
+    "blacklistTabular": null,
+    "maxError": 1,
+    "compRows": 200000,
+    "purpose": "ENRICHED_EVENTS",
+    "sshTunnel": null
+  }
+}

--- a/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/redshift-config-3
+++ b/spec/snowplow-emr-etl-runner/resources/blacklist-tabular/redshift-config-3
@@ -1,0 +1,23 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/3-0-0",
+  "data": {
+    "name": "com.snplow.eng.aws-dev1 Redshift",
+    "id": "354a3d25-7dc2-9c31-5605-19d6fd819efa",
+    "host": "sp-com-snplow-eng-aws-prod1-redshift-cluster.cdzqkzl74pqa.eu-central-1.redshift.amazonaws.com",
+    "database": "dev1",
+    "port": 5439,
+    "roleArn": "arn:aws:iam::866038399814:role/sp-com-snplow-eng-aws-prod1-redshift-load",
+    "schema": "atomic",
+    "username": "storageloader",
+    "password": "123",
+    "jdbc": {
+      "ssl": true
+    },
+    "processingManifest": null,
+    "blacklistTabular": ["iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-2"],
+    "maxError": 1,
+    "compRows": 200000,
+    "purpose": "ENRICHED_EVENTS",
+    "sshTunnel": null
+  }
+}


### PR DESCRIPTION
Logic:
- Not copy shredded JSONs only if shredder version >= 0.16.0 and tabularBlacklist is an empty array
- Copy shredded TSVs only if shredder version >= 0.16.0 and tabularBlacklist exists and is an array
